### PR TITLE
Make trailing colon on class manipulation clear

### DIFF
--- a/_includes/manipulationIntro.md
+++ b/_includes/manipulationIntro.md
@@ -4,7 +4,7 @@
   <article class="equalize" data-pattern="2">
     <h3>Class Manipulations</h3>
     <section>
-      <p>The simplest intentional attribute is a class manipulation. This manipulation adds the current context as a class to the element. Adding <code>in-axis_name</code> to a flagged element is enough to get it working.</p>
+      <p>The simplest intentional attribute is a class manipulation. This manipulation adds the current context as a class to the element. Adding <code>in-axis_name:</code> (note the trailing colon) to a flagged element is enough to get it working.</p>
     </section>
     <section>
       {%highlight html%}


### PR DESCRIPTION
I got stuck on class manipulation because I thought that the trailing colon on the documentation was just a typo and therefore didn't include it in my code. I think it should be more clear on the doc:

Before:
![image](https://f.cloud.github.com/assets/992008/1356340/b95ae5ce-3775-11e3-94e4-1e967cf688b0.png)

After:
![image](https://f.cloud.github.com/assets/992008/1356334/a2fcd67a-3775-11e3-9e45-c7d5ef7061b4.png)
